### PR TITLE
Persist Changes by Updating Chore Data

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ function fetchChores() {
   fetch(choresUrl)
     .then((response) => response.json())
     .then((data) => {
+      const currentCards = document.querySelectorAll(".card");
+      currentCards.forEach((card) => card.remove());
       data.forEach((chore) => {
         displayChore(chore);
       });
@@ -142,7 +144,7 @@ newChoreForm.addEventListener("submit", (event) => {
   })
     .then((response) => response.json())
     .then(() => {
-      displayChore(newChore);
+      fetchChores();
       newChoreForm.reset();
     });
 });

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function displayChore(chore) {
 
   const deleteBtn = document.createElement("button");
   deleteBtn.textContent = "Delete";
-  deleteBtn.addEventListener("click", () => deleteChore(choreCard));
+  deleteBtn.addEventListener("click", () => deleteChore(chore));
 
   checkIfDone.append(checkbox);
   choreCard.append(name, priority, checkIfDone, editBtn, deleteBtn);
@@ -126,8 +126,18 @@ function editChore(chore, choreCard) {
   });
 }
 
-function deleteChore(choreCard) {
-  choreCard.remove();
+function deleteChore(chore) {
+  fetch(choresUrl + chore.id, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then(() => {
+      fetchChores();
+    });
 }
 
 newChoreForm.addEventListener("submit", (event) => {

--- a/index.js
+++ b/index.js
@@ -132,6 +132,17 @@ newChoreForm.addEventListener("submit", (event) => {
     priority: priorityInput,
   };
 
-  displayChore(newChore);
-  newChoreForm.reset();
+  fetch(choresUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(newChore),
+  })
+    .then((response) => response.json())
+    .then(() => {
+      displayChore(newChore);
+      newChoreForm.reset();
+    });
 });

--- a/index.js
+++ b/index.js
@@ -113,8 +113,16 @@ function editChore(chore, choreCard) {
       priority: editPriority.value,
     };
 
-    choreCard.remove();
-    displayChore(updatedChore);
+    fetch(choresUrl + chore.id, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(updatedChore),
+    })
+      .then((response) => response.json())
+      .then(() => fetchChores());
   });
 }
 


### PR DESCRIPTION
When users add a new chore, update or delete an existing chore, these changes will now be communicated to the server and persist across page loads.